### PR TITLE
Fix re-render use case

### DIFF
--- a/build/cjs/RemoteFramesProvider.js
+++ b/build/cjs/RemoteFramesProvider.js
@@ -58,6 +58,17 @@ var RemoteFramesProvider = function (_Component) {
   }
 
   _createClass(RemoteFramesProvider, [{
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate(prevProps) {
+      if (this.props.targetDomElement !== prevProps.targetDomElement) {
+        if (this.props.targetDomElement instanceof HTMLElement) {
+          this.renderGlobalTarget(this.props.targetDomElement);
+        } else {
+          this.props.targetDomElement.then(this.renderGlobalTarget.bind(this));
+        }
+      }
+    }
+  }, {
     key: 'componentDidMount',
     value: function componentDidMount() {
       if (this.props.targetDomElement instanceof HTMLElement) {
@@ -95,8 +106,6 @@ var RemoteFramesProvider = function (_Component) {
             removeFromRemote(renderInformation);
           }
         });
-
-        delete _this2.queue;
       });
     }
   }, {

--- a/build/esm/RemoteFramesProvider.js
+++ b/build/esm/RemoteFramesProvider.js
@@ -41,6 +41,17 @@ var RemoteFramesProvider = function (_Component) {
   }
 
   _createClass(RemoteFramesProvider, [{
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate(prevProps) {
+      if (this.props.targetDomElement !== prevProps.targetDomElement) {
+        if (this.props.targetDomElement instanceof HTMLElement) {
+          this.renderGlobalTarget(this.props.targetDomElement);
+        } else {
+          this.props.targetDomElement.then(this.renderGlobalTarget.bind(this));
+        }
+      }
+    }
+  }, {
     key: 'componentDidMount',
     value: function componentDidMount() {
       if (this.props.targetDomElement instanceof HTMLElement) {
@@ -78,8 +89,6 @@ var RemoteFramesProvider = function (_Component) {
             removeFromRemote(renderInformation);
           }
         });
-
-        delete _this2.queue;
       });
     }
   }, {

--- a/src/RemoteFramesProvider.js
+++ b/src/RemoteFramesProvider.js
@@ -29,6 +29,16 @@ class RemoteFramesProvider extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.targetDomElement !== prevProps.targetDomElement) {
+      if (this.props.targetDomElement instanceof HTMLElement) {
+        this.renderGlobalTarget(this.props.targetDomElement)
+      } else {
+        this.props.targetDomElement.then(this.renderGlobalTarget.bind(this))
+      }
+    }
+  }
+
   componentDidMount() {
     if (this.props.targetDomElement instanceof HTMLElement) {
       this.renderGlobalTarget(this.props.targetDomElement)
@@ -62,8 +72,6 @@ class RemoteFramesProvider extends Component {
             removeFromRemote(renderInformation)
           }
         })
-
-        delete this.queue
       }
     )
   }

--- a/src/example/FakeArticle/container.js
+++ b/src/example/FakeArticle/container.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import ArticleComponent from './component'
-import RemoteFrame from '../../RemoteFrame'
+import RemoteFrame from '../../remote-frame'
 
 class ArticleContainer extends React.Component {
   render() {
@@ -13,13 +13,11 @@ class ArticleContainer extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
-  return {
-    likes: state.likes,
-    red: state.red,
-    green: state.green,
-  }
-}
+const mapStateToProps = state => ({
+  likes: state.likes,
+  red: state.red,
+  green: state.green,
+})
 
 let globalDispatch = () => {}
 
@@ -37,4 +35,9 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(ArticleContainer)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  null,
+  { pure: false }
+)(ArticleContainer)

--- a/src/example/Section/index.js
+++ b/src/example/Section/index.js
@@ -4,7 +4,11 @@ import { compose, defaultProps, getContext } from 'recompose'
 
 const Section = ({ values }) => (
   <section>
-    <ul>{values.map(value => <li key={value}>{value}</li>)}</ul>
+    <ul>
+      {values.map(value => (
+        <li key={value}>{value}</li>
+      ))}
+    </ul>
   </section>
 )
 

--- a/src/example/noProvider.js
+++ b/src/example/noProvider.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from 'react-dom'
-import RemoteFrame from '../RemoteFrame'
+import RemoteFrame from '../remote-frame'
 
 render(
   <div>

--- a/src/example/source.js
+++ b/src/example/source.js
@@ -3,7 +3,7 @@ import { render } from 'react-dom'
 import { withContext } from 'recompose'
 import PropTypes from 'prop-types'
 import RemoteFramesProvider from '../RemoteFramesProvider'
-import RemoteFrame from '../RemoteFrame'
+import RemoteFrame from '../remote-frame'
 import FakeArticle from './FakeArticle'
 import Section from './Section'
 


### PR DESCRIPTION
When remote frames provider was updated with a new targetDomElement reference, it didn't work, cause:

- The queue was being deleted
- It was missing componentDidUpdate necessary steps to re-render the global target into the new reference

Fixes:

- Keep queue
- Add compoennt did update rerendering global target into new reference