### PR TITLE
Adding the wrapperComponent prop to RemoteFramesProvider

### DIFF
--- a/src/RemoteFramesProvider.js
+++ b/src/RemoteFramesProvider.js
@@ -65,7 +65,7 @@ class RemoteFramesProvider extends Component {
   }
 
   renderGlobalTarget(targetDomElement) {
-    const Target = (
+    const target = (
       <GlobalTarget
         onAddStackElement={this.props.onFrameAdded}
         onEmptyStack={this.props.onNoFrames}
@@ -78,13 +78,13 @@ class RemoteFramesProvider extends Component {
     if (WrapperComponent) {
       render(
         <WrapperComponent>
-          <Target />
+          {target}
         </WrapperComponent>,
         targetDomElement
       )
     } else {
       render(
-        <Target />,
+        target,
         targetDomElement
       )
     }

--- a/src/RemoteFramesProvider.js
+++ b/src/RemoteFramesProvider.js
@@ -65,14 +65,29 @@ class RemoteFramesProvider extends Component {
   }
 
   renderGlobalTarget(targetDomElement) {
-    render(
+    const Target = (
       <GlobalTarget
         onAddStackElement={this.props.onFrameAdded}
         onEmptyStack={this.props.onNoFrames}
         onReady={this.handleOnReady.bind(this)}
-      />,
-      targetDomElement
+      />
     )
+
+    const WrapperComponent = this.props.wrapperComponent
+
+    if (WrapperComponent) {
+      render(
+        <WrapperComponent>
+          <Target />
+        </WrapperComponent>,
+        targetDomElement
+      )
+    } else {
+      render(
+        <Target />,
+        targetDomElement
+      )
+    }
   }
 
   handleOnReady(renderInRemote, removeFromRemote) {


### PR DESCRIPTION
We now are able to wrap the `GlobalTarget` inside remote-frames with any HOC we would need to.