### PR TITLE
Removing invalid context types

### DIFF
--- a/src/remote-frame/index.js
+++ b/src/remote-frame/index.js
@@ -66,11 +66,6 @@ const createCapturedContextComponent = (contextTypes = {}) => {
     ...contextTypes,
   }
 
-  CapturedContextComponent.childContextTypes = {
-    callBackContainer: PropTypes.object,
-    ...contextTypes,
-  }
-
   capturedContextComponentsCache.push([contextTypes, CapturedContextComponent])
 
   return CapturedContextComponent


### PR DESCRIPTION
`childContextTypes` is only intended for Context provider, not consumers. Remove the provider types from the consumer.