### PR TITLE
add onRemoveFrame callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ class App extends Component {
           frameJSX
         )
       }}
+      onFrameRemoved={frameJSX => {
+        console.log(
+          'a frame was removed from the dialogs-node stack',
+          frameJSX
+        )
+      }}
       onNoFrames={lastJSXRemoved => {
         console.log(
           'all frames have been removed from the stack',
@@ -186,8 +192,9 @@ render(
 
 Two callbacks are available on `RemoteFramesProvider`:
 
-- `onFrameAdded`: gets call whenever another frame is added to the stack
-- `onNoFrames`: gets call whenever all frames are removed from the stack
+- `onFrameAdded`: gets called whenever another frame is added to the stack
+- `onNoFrames`: gets called whenever all frames are removed from the stack
+- `onFrameRemoved`: gets called whenever a frame is removed from the stack
 
 ### Passing the `targetDomElement`
 

--- a/src/GlobalTarget.js
+++ b/src/GlobalTarget.js
@@ -64,6 +64,8 @@ class GlobalTarget extends Component {
           stack: stack.filter(({ type }) => type !== jsx.type),
         }),
         () => {
+          this.props.onRemoveStackElement(jsx)
+
           if (this.state.stack.length === 0) {
             this.props.onEmptyStack(jsx)
           }
@@ -97,6 +99,7 @@ class GlobalTarget extends Component {
 GlobalTarget.defaultProps = {
   onAddStackElement: () => {},
   onEmptyStack: () => {},
+  onRemoveStackElement: () => {}
 }
 
 export default GlobalTarget

--- a/src/RemoteFramesProvider.js
+++ b/src/RemoteFramesProvider.js
@@ -73,6 +73,7 @@ class RemoteFramesProvider extends Component {
       <GlobalTarget
         onAddStackElement={this.props.onFrameAdded}
         onEmptyStack={this.props.onNoFrames}
+        onRemoveStackElement={this.props.onFrameRemoved}
         onReady={this.handleOnReady.bind(this)}
       />
     )

--- a/src/example/source.js
+++ b/src/example/source.js
@@ -49,6 +49,7 @@ class Demo extends Component {
         }
         onFrameAdded={jsx => console.log('onFrameAdded', jsx)}
         onNoFrames={jsx => console.log('onNoFrames', jsx)}
+        onFrameRemoved={jsx => console.log('onFrameRemoved', jsx)}
       >
         <Wrapper>
           {this.state.initial || (


### PR DESCRIPTION
Instead of only tracking "no frames", being able to track when "a frame has been removed" despite the current stack size is handy when you have no control over the frames added. For example, when using other modules that use remote frames.