### PR TITLE
Unmount existing GlobalTarget before rendering new in same target DOM element

### DIFF
--- a/src/RemoteFramesProvider.js
+++ b/src/RemoteFramesProvider.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import {render} from 'react-dom'
+import {render, unmountComponentAtNode} from 'react-dom'
 import GlobalTarget from './GlobalTarget'
+
 // We need this in order to not relay on the consumer to make sure that the context is updated
 // With this pattern we need just to be sure the context is set at the first time, then we take care of updating it.
 // The consumer should take care of propagating its own context
@@ -69,6 +70,8 @@ class RemoteFramesProvider extends Component {
   }
 
   renderGlobalTarget(targetDomElement) {
+    unmountComponentAtNode(targetDomElement)
+
     const target = (
       <GlobalTarget
         onAddStackElement={this.props.onFrameAdded}


### PR DESCRIPTION
Currently, when switching from one `targetDomElement` to another and then back again to the same one, remote frames do not render. That's because the `GlobalTarget` is not remounted and the remote frames are added to the previous stack instead due to `renderInRemote` and `removeFromRemote` not being updated in the context.

In order to fix this, any existing `GlobalTarget` is unmounted using `ReactDOM.unmountComponentAtNode` before rendering again in the same `targetDomElement`.

#### Without fix
<img width="738" alt="remote-frames-issue-without-fix" src="https://user-images.githubusercontent.com/867129/95627889-43d2a480-0a7d-11eb-867f-303a513b472b.png">


#### With fix
<img width="742" alt="remote-frames-issue-with-fix" src="https://user-images.githubusercontent.com/867129/95627892-47662b80-0a7d-11eb-8b7e-3b465e4e9b8a.png">
