### PR TITLE
Fix a bug with Context Parent component changing all the time, causing RemoteFrames to be remounted.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@klarna/remote-frames",
   "version": "0.3.7",
   "description": "Render a subset of the React tree to a different location, from many locations, without having to coordinate them",
-  "main": "build/esm/index.js",
+  "main": "src/index.js",
+  "module": "build/esm/index.js",
   "scripts": {
     "clean": "rimraf -- build",
     "build:esm": "cross-env BABEL_ENV=esm babel src/ --copy-files --out-dir build/esm/ --ignore spec.js,example/",

--- a/src/GlobalTarget.js
+++ b/src/GlobalTarget.js
@@ -28,8 +28,6 @@ class GlobalTarget extends Component {
 
     this.stackTypes = []
 
-    this.SetContextComponent = createSetContextComponent({})
-
     this.state = {
       stack: [],
     }

--- a/src/GlobalTarget.js
+++ b/src/GlobalTarget.js
@@ -83,11 +83,8 @@ class GlobalTarget extends Component {
       <React.Fragment>
         {stack.map(({jsx, SetContextComponent, context}, index) => {
           return (
-            <SetContextComponent context={context}>
-              <div
-                key={index}
-                style={{ display: index === stack.length - 1 ? 'block' : 'none' }}
-              >
+            <SetContextComponent key={index} context={context}>
+              <div style={{ display: index === stack.length - 1 ? 'block' : 'none' }}>
                 {jsx}
               </div>
             </SetContextComponent>

--- a/src/GlobalTarget.js
+++ b/src/GlobalTarget.js
@@ -37,21 +37,23 @@ class GlobalTarget extends Component {
 
   componentDidMount() {
     this.renderInRemote = ({ jsx, context, contextTypes }) => {
-      this.SetContextComponent = createSetContextComponent(contextTypes)
+      const newStackItem = {
+        jsx,
+        SetContextComponent: createSetContextComponent(contextTypes),
+        context
+      };
 
       if (this.stackTypes.filter(type => type === jsx.type).length === 0) {
         this.stackTypes = [...this.stackTypes, jsx.type]
 
         this.setState(({ stack }) => ({
-          context,
-          stack: [...stack, jsx],
+          stack: [...stack, newStackItem],
         }))
 
         this.props.onAddStackElement(jsx)
       } else {
         this.setState(({ stack }) => ({
-          context,
-          stack: stack.map(item => (item.type === jsx.type ? jsx : item)),
+          stack: stack.map(item => (item.jsx.type === jsx.type ? newStackItem : item)),
         }))
       }
     }
@@ -61,7 +63,7 @@ class GlobalTarget extends Component {
 
       this.setState(
         ({ stack }) => ({
-          stack: stack.filter(({ type }) => type !== jsx.type),
+          stack: stack.filter(item => item.jsx.type !== jsx.type),
         }),
         () => {
           this.props.onRemoveStackElement(jsx)
@@ -77,21 +79,23 @@ class GlobalTarget extends Component {
   }
 
   render() {
-    const { context, stack } = this.state
+    const { stack } = this.state
 
     return (
-      <this.SetContextComponent context={context}>
-        {stack.map((jsx, index) => {
+      <React.Fragment>
+        {stack.map(({jsx, SetContextComponent, context}, index) => {
           return (
-            <div
-              key={index}
-              style={{ display: index === stack.length - 1 ? 'block' : 'none' }}
-            >
-              {jsx}
-            </div>
+            <SetContextComponent context={context}>
+              <div
+                key={index}
+                style={{ display: index === stack.length - 1 ? 'block' : 'none' }}
+              >
+                {jsx}
+              </div>
+            </SetContextComponent>
           )
         })}
-      </this.SetContextComponent>
+      </React.Fragment>
     )
   }
 }


### PR DESCRIPTION
### Bug Scenario

- Consider you have a **ComponentA** wrapped in RemoteFrame.
- **ComponentA** contains children ( **ComponentB** ) and under certain conditions they are wrapped in **RemoteFrame**.
- Adding a new **RemoteFrame** to the stack, would trigger **renderInRemote** that adds element to the stack and causes **GlobalTarget** re-render.
- Render method of **GlobalTarget** is the problem, as it always wraps all elements of the stack ( **ComponentA**, **ComponentB** ) in the current active **RemoteFrame** context container in the code as **this.SetContextComponent**.
- If in **React** you change the parent of a certain component that will cause that component and it's parent to be removed from the virtual DOM of React and later on when reattached they will remount.

### Visualised

Start scenario of **GlobalTarget**. Stack has 1 element **RemoteFrame0**. For this element the calculated **this.SetContextComponent** is **ContextDeterminedAtTime0**.

```jsx
<ContextDeterminedAtTime0>
	<RemoteFrame0>
		<button>Click to add RemoteFrame to the stack</button>
	</RemoteFrame0>
</ContextDeterminedAtTime0>
```

After click of button. New **RemoteFrame** is added to the stack. This causes **this.SetContextComponent** to be recalculated and the new value is **ContextDeterminedAtTimeOfClick**. Notice that now **RemoteFrame0** and **RemoteFrame1** will have a new parent **ContextDeterminedAtTimeOfClick**. This will cause remounting of the **RemoteFrame0** which was mounted before and a new mount for **RemoteFrame1**.

```jsx
<ContextDeterminedAtTimeOfClick>
	<RemoteFrame0>
		<button>Add frame 1</button>
	</RemoteFrame0>
	<RemoteFrame1>
		New frame
	</RemoteFrame1>
</ContextDeterminedAtTimeOfClick>
```

### Proposed solution

- Each **RemoteFrame** of the stack should know about it's own context. 
- There shouldn't be a context change for a given element of the stack when new **RemoteFrame** is added.
- Extend stack structure not to include **jsx** element only but to keep track of the **context** + **SetContextComponent** for that specific **jsx**

