### PR TITLE
Remote frames shouldnt rely on jsx type for delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/remote-frames",
-  "version": "0.3.10",
+  "version": "0.3.9",
   "description": "Render a subset of the React tree to a different location, from many locations, without having to coordinate them",
   "main": "src/index.js",
   "module": "build/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/remote-frames",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Render a subset of the React tree to a different location, from many locations, without having to coordinate them",
   "main": "src/index.js",
   "module": "build/esm/index.js",

--- a/src/GlobalTarget.js
+++ b/src/GlobalTarget.js
@@ -26,23 +26,21 @@ class GlobalTarget extends Component {
   constructor() {
     super()
 
-    this.stackTypes = []
-
     this.state = {
       stack: [],
     }
   }
 
   componentDidMount() {
-    this.renderInRemote = ({ jsx, context, contextTypes }) => {
+    this.renderInRemote = ({ jsx, context, contextTypes, id }) => {
       const newStackItem = {
         jsx,
         SetContextComponent: createSetContextComponent(contextTypes),
-        context
+        context,
+        id
       };
-
-      if (this.stackTypes.filter(type => type === jsx.type).length === 0) {
-        this.stackTypes = [...this.stackTypes, jsx.type]
+      const stackTypes = this.state.stack.map(({jsx}) => jsx.type);
+      if (stackTypes.filter(type => type === jsx.type).length === 0) {
 
         this.setState(({ stack }) => ({
           stack: [...stack, newStackItem],
@@ -56,12 +54,10 @@ class GlobalTarget extends Component {
       }
     }
 
-    this.removeFromRemote = jsx => {
-      this.stackTypes = this.stackTypes.filter(type => type !== jsx.type)
-
+    this.removeFromRemote = ({jsx, id}) => {
       this.setState(
         ({ stack }) => ({
-          stack: stack.filter(item => item.jsx.type !== jsx.type),
+          stack: stack.filter(item => item.id !== id),
         }),
         () => {
           this.props.onRemoveStackElement(jsx)

--- a/src/RemoteFramesProvider.js
+++ b/src/RemoteFramesProvider.js
@@ -35,13 +35,13 @@ class RemoteFramesProvider extends Component {
           )
         }
         this.queue.push(['render', renderInformation])
-      }, jsx => {
+      }, renderInformation => {
         if (this.queue == null) {
           throw new Error(
             'The queue in the RemoteFramesProvider was flushed, yet the RemoteFrame is trying to use the `removeFromRemote` that will add to the queue. This means the RemoteFrame did not pick up the React.context update: check the elements in between, if they are intercepting the context in some way.'
           )
         }
-        this.queue.push(['remove', jsx])
+        this.queue.push(['remove', renderInformation])
       }
     )
     this.queue = []

--- a/src/remote-frame/index.js
+++ b/src/remote-frame/index.js
@@ -4,7 +4,7 @@ import equals from 'ramda/src/equals'
 
 const capturedContextComponentsCache = []
 
-const doRemoteRender = (renderInRemote, context, contextTypes, children) => {
+const doRemoteRender = (renderInRemote, context, contextTypes, children, id) => {
   renderInRemote({
     jsx: children,
     context: Object.keys(contextTypes).reduce(
@@ -15,6 +15,7 @@ const doRemoteRender = (renderInRemote, context, contextTypes, children) => {
       {}
     ),
     contextTypes,
+    id
   })
 }
 
@@ -36,7 +37,8 @@ const createCapturedContextComponent = (contextTypes = {}) => {
         renderInRemote,
         this.context,
         { callBackContainer: PropTypes.object, ...contextTypes },
-        children
+        children,
+        this.uniqueId
       )
     }
 
@@ -79,6 +81,7 @@ const createCapturedContextComponent = (contextTypes = {}) => {
 class RemoteFrame extends Component {
   constructor(props, context) {
     super(props, context)
+    this.uniqueId = Date.now().toString(36) + Math.random().toString(36).substring(2);
 
     if (context.callBackContainer != null) {
       this.CapturedContextComponent = createCapturedContextComponent({
@@ -102,7 +105,7 @@ class RemoteFrame extends Component {
 
   componentWillUnmount() {
     if (this.context.callBackContainer != null) {
-      this.context.callBackContainer.removeFromRemote(this.props.children)
+      this.context.callBackContainer.removeFromRemote({jsx: this.props.children, id: this.uniqueId})
     }
   }
 


### PR DESCRIPTION
RemoteFrame removal depends on the `jsx.type`. This is creating bugs and code in integrators attempts to address this by passing different **RemoteFrame** children wrappers.

Scenario:

```jsx
<RemoteFramesProvider>
      {<RemoteFrame>
          <ComponentA>
               Content A
          <ComponentA />
      </RemoteFrame>}
      
      {this.state.bShown && <RemoteFrame>
          <ComponentA>
                Content B <button onClick={this.makeBShownFalse} />
          <ComponentA />
      </RemoteFrame>}
</RemoteFramesProvider>
```
If we press on the button it will remove 2 frames from the **GlobalTarget (this.state.stack)** since the jsx.type is the same **ComponentA** and removal is done by using **jsx.type**.